### PR TITLE
bug: Potential deadlock in bolt handshake

### DIFF
--- a/neobolt/direct.py
+++ b/neobolt/direct.py
@@ -871,15 +871,10 @@ def _handshake(s, resolved_address, der_encoded_server_certificate, **config):
     s.sendall(data)
 
     # Handle the handshake response
-    ready_to_read = False
-    while not ready_to_read:
-        ready_to_read, _, _ = select((s,), (), (), 1)
-
-        timeout = config.get("connection_timeout", DEFAULT_CONNECTION_TIMEOUT)
-        connection_timeout = (perf_counter() - start_timestamp) > timeout
-        if not ready_to_read and connection_timeout:
-            message = "Failed to read any data from server {!r} after connected".format(resolved_address)
-            raise ServiceUnavailable(message)
+    timeout = config.get("connection_timeout", DEFAULT_CONNECTION_TIMEOUT)
+    ready_to_read, _, _ = select((s,), (), (), timeout)
+    if not ready_to_read:
+        raise ServiceUnavailable("Failed to read any data from server {!r} after connected".format(resolved_address))
 
     try:
         data = s.recv(4)


### PR DESCRIPTION
Notes:
 - There is no timeout when waiting to read, this will block a thread until the server responds
 - Added a check using the connection_timeout from config or Default to raise a ServiceUnavailable if a host stops responding

Test Repro:
 - Point your python app at Neo4J running in Docker
 - Docker pause <container>
 - Will deadlock triyng to retrieve a *new* connection