### PR TITLE
Boltkit 1.3.1 breaks tests.

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,4 @@
-boltkit>=1.0.39
+boltkit==1.3.0
 coverage
 mock
 pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27
+    # py27
     py34
     py35
     py36


### PR DESCRIPTION
Specify to use boltkit version == 1.3.0